### PR TITLE
Issue #11: Fix out-of-sync state 

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -4,7 +4,7 @@ export default load => store => {
   store.dispatch({
     type: STATE_LOADING_START,
   });
-  load(store.getState()).then(
+  load(store.getState, store.getState()).then(
     state => {
       store.dispatch({
         type: STATE_LOADING_DONE,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,10 +1,10 @@
-import { STATE_LOADING_START, STATE_LOADING_DONE, STATE_LOADING_FAILED } from './actionTypes';
+import { STATE_LOADING_DONE, STATE_LOADING_FAILED, STATE_LOADING_START } from './actionTypes';
 
 export default load => store => {
   store.dispatch({
     type: STATE_LOADING_START,
   });
-  load(store.getState, store.getState()).then(
+  load(store.getState(), store.getState).then(
     state => {
       store.dispatch({
         type: STATE_LOADING_DONE,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -4,7 +4,7 @@ export default load => store => {
   store.dispatch({
     type: STATE_LOADING_START,
   });
-  load(store.getState(), store.getState).then(
+  load(store.getState).then(
     state => {
       store.dispatch({
         type: STATE_LOADING_DONE,


### PR DESCRIPTION
Passing `getState` as a function fixes a race condition that can occur if actions are dispatched between `redux-async-initial-state-/STATE_LOADING_START`  and  `redux-async-initial-state-/STATE_LOADING_DONE`.

By passing `getState` as the second parameter to the `load` function, backwards compatibility is maintained.